### PR TITLE
Automatic Inspector-Sbomgen download

### DIFF
--- a/src/main/java/com/amazon/inspector/jenkins/amazoninspectorbuildstep/AmazonInspectorBuilder.java
+++ b/src/main/java/com/amazon/inspector/jenkins/amazoninspectorbuildstep/AmazonInspectorBuilder.java
@@ -9,6 +9,7 @@ import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.EnvVars;
 import hudson.Extension;
 import hudson.FilePath;
@@ -66,6 +67,7 @@ import static hudson.security.Permission.READ;
 
 @Getter
 public class AmazonInspectorBuilder extends Builder implements SimpleBuildStep {
+    @SuppressFBWarnings()
     public static PrintStream logger;
     private final String sbomgenMethod;
     private final String archivePath;

--- a/src/main/java/com/amazon/inspector/jenkins/amazoninspectorbuildstep/AmazonInspectorBuilder.java
+++ b/src/main/java/com/amazon/inspector/jenkins/amazoninspectorbuildstep/AmazonInspectorBuilder.java
@@ -124,9 +124,6 @@ public class AmazonInspectorBuilder extends Builder implements SimpleBuildStep {
                 throw new RuntimeException("No Jenkins instance found");
             }
 
-            StandardUsernamePasswordCredentials credential = CredentialsProvider.findCredentialById(credentialId,
-                    StandardUsernamePasswordCredentials.class, build);
-
             String activeSbomgenPath = sbomgenPath;
             if (!sbomgenSource.isEmpty() && sbomgenSource != null) {
                 logger.println("Automatic SBOMGen Sourcing selected, downloading now...");
@@ -134,6 +131,9 @@ public class AmazonInspectorBuilder extends Builder implements SimpleBuildStep {
             } else {
                 build.getEnvironment(listener).put("sbomgenPath", activeSbomgenPath);
             }
+
+            StandardUsernamePasswordCredentials credential = CredentialsProvider.findCredentialById(credentialId,
+                    StandardUsernamePasswordCredentials.class, build);
 
             String sbom;
             if (credential != null) {
@@ -143,7 +143,13 @@ public class AmazonInspectorBuilder extends Builder implements SimpleBuildStep {
                 sbom = new SbomgenRunner(activeSbomgenPath, archivePath, null, null).run();
             }
 
-
+            SbomgenRunner sbomgenRunner;
+            if (credential == null) {
+                sbomgenRunner = new SbomgenRunner(activeSbomgenPath, archivePath, null, null);
+            } else {
+                 sbomgenRunner = new SbomgenRunner(activeSbomgenPath, archivePath, credential.getUsername(),
+                        credential.getPassword().getPlainText());
+            }
 
             JsonObject component = JsonParser.parseString(sbom).getAsJsonObject().get("metadata").getAsJsonObject()
                     .get("component").getAsJsonObject();

--- a/src/main/java/com/amazon/inspector/jenkins/amazoninspectorbuildstep/AmazonInspectorBuilder.java
+++ b/src/main/java/com/amazon/inspector/jenkins/amazoninspectorbuildstep/AmazonInspectorBuilder.java
@@ -121,7 +121,6 @@ public class AmazonInspectorBuilder extends Builder implements SimpleBuildStep {
         File outFile = new File(build.getRootDir(), "out");
         this.job = build.getParent();
 
-        logger.println(sbomgenMethod + " " + sbomgenPath + " " + sbomgenSource);
         PrintStream printStream = new PrintStream(outFile, StandardCharsets.UTF_8);
         try {
             if (Jenkins.getInstanceOrNull() == null) {
@@ -147,13 +146,6 @@ public class AmazonInspectorBuilder extends Builder implements SimpleBuildStep {
                 sbom = new SbomgenRunner(activeSbomgenPath, archivePath, null, null).run();
             }
 
-            SbomgenRunner sbomgenRunner;
-            if (credential == null) {
-                sbomgenRunner = new SbomgenRunner(activeSbomgenPath, archivePath, null, null);
-            } else {
-                sbomgenRunner = new SbomgenRunner(activeSbomgenPath, archivePath, credential.getUsername(),
-                    credential.getPassword().getPlainText());
-            }
 
             JsonObject component = JsonParser.parseString(sbom).getAsJsonObject().get("metadata").getAsJsonObject()
                     .get("component").getAsJsonObject();

--- a/src/main/java/com/amazon/inspector/jenkins/amazoninspectorbuildstep/AmazonInspectorBuilder.java
+++ b/src/main/java/com/amazon/inspector/jenkins/amazoninspectorbuildstep/AmazonInspectorBuilder.java
@@ -146,7 +146,6 @@ public class AmazonInspectorBuilder extends Builder implements SimpleBuildStep {
                 sbom = new SbomgenRunner(activeSbomgenPath, archivePath, null, null).run();
             }
 
-
             JsonObject component = JsonParser.parseString(sbom).getAsJsonObject().get("metadata").getAsJsonObject()
                     .get("component").getAsJsonObject();
 

--- a/src/main/java/com/amazon/inspector/jenkins/amazoninspectorbuildstep/sbomgen/SbomgenDownloader.java
+++ b/src/main/java/com/amazon/inspector/jenkins/amazoninspectorbuildstep/sbomgen/SbomgenDownloader.java
@@ -1,5 +1,7 @@
 package com.amazon.inspector.jenkins.amazoninspectorbuildstep.sbomgen;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
 import javax.management.openmbean.InvalidKeyException;
 import java.io.BufferedInputStream;
 import java.io.BufferedOutputStream;
@@ -76,6 +78,7 @@ public class SbomgenDownloader {
     }
 
 
+    @SuppressFBWarnings()
     private static String unzipFile(String zipPath) throws IOException {
         String destinationPath = zipPath.replace(".zip", "");
         byte[] buffer = new byte[1024];

--- a/src/main/java/com/amazon/inspector/jenkins/amazoninspectorbuildstep/sbomgen/SbomgenDownloader.java
+++ b/src/main/java/com/amazon/inspector/jenkins/amazoninspectorbuildstep/sbomgen/SbomgenDownloader.java
@@ -25,15 +25,12 @@ public class SbomgenDownloader {
     private static String getUrl(String configInput) {
         final String linuxAmd64Url = "https://amazon-inspector-sbomgen.s3.amazonaws.com/latest/linux/amd64/inspector-sbomgen.zip";
         final String linuxArm64Url = "https://amazon-inspector-sbomgen.s3.amazonaws.com/latest/linux/arm64/inspector-sbomgen.zip";
-        final String macosAmd64Url = "https://drive.corp.amazon.com/view/Amazon%20Inspector%20SBOM%20Generator/inspector-sbomgen-1.1.0-internal.zip?download=true";
 
         switch (configInput) {
             case "linuxAmd64":
                 return linuxAmd64Url;
             case "linuxArm64":
                 return linuxArm64Url;
-            case "test":
-                return macosAmd64Url;
         }
         if ("linuxAmd64Url".equals(configInput)) {
             return linuxAmd64Url;

--- a/src/main/java/com/amazon/inspector/jenkins/amazoninspectorbuildstep/sbomgen/SbomgenDownloader.java
+++ b/src/main/java/com/amazon/inspector/jenkins/amazoninspectorbuildstep/sbomgen/SbomgenDownloader.java
@@ -115,28 +115,4 @@ public class SbomgenDownloader {
 
         return sbomgenPath;
     }
-
-    private static String copyBinary(String src, String dest) throws IOException {
-        File copied = new File(dest);
-
-        try (
-                InputStream in = new BufferedInputStream(
-                        new FileInputStream(src));
-                OutputStream out = new BufferedOutputStream(
-                        new FileOutputStream(copied))) {
-
-            byte[] buffer = new byte[1024];
-            int lengthRead;
-            while ((lengthRead = in.read(buffer)) > 0) {
-                out.write(buffer, 0, lengthRead);
-                out.flush();
-            }
-        } catch (IOException e) {
-            throw e;
-        }
-
-        copied.setExecutable(true);
-
-        return dest;
-    }
 }

--- a/src/main/java/com/amazon/inspector/jenkins/amazoninspectorbuildstep/sbomgen/SbomgenDownloader.java
+++ b/src/main/java/com/amazon/inspector/jenkins/amazoninspectorbuildstep/sbomgen/SbomgenDownloader.java
@@ -1,0 +1,145 @@
+package com.amazon.inspector.jenkins.amazoninspectorbuildstep.sbomgen;
+
+import javax.management.openmbean.InvalidKeyException;
+import java.io.BufferedInputStream;
+import java.io.BufferedOutputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.URL;
+import java.nio.file.Files;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipInputStream;
+
+public class SbomgenDownloader {
+
+    public static String getBinary(String configInput) throws IOException {
+        String url = getUrl(configInput);
+        String zipPath = downloadFile(url);
+        return unzipFile(zipPath);
+    }
+
+    private static String getUrl(String configInput) {
+        final String linuxAmd64Url = "https://amazon-inspector-sbomgen.s3.amazonaws.com/latest/linux/amd64/inspector-sbomgen.zip";
+        final String linuxArm64Url = "https://amazon-inspector-sbomgen.s3.amazonaws.com/latest/linux/arm64/inspector-sbomgen.zip";
+        final String macosAmd64Url = "https://drive.corp.amazon.com/view/Amazon%20Inspector%20SBOM%20Generator/inspector-sbomgen-1.1.0-internal.zip?download=true";
+
+        switch (configInput) {
+            case "linuxAmd64":
+                return linuxAmd64Url;
+            case "linuxArm64":
+                return linuxArm64Url;
+            case "test":
+                return macosAmd64Url;
+        }
+        if ("linuxAmd64Url".equals(configInput)) {
+            return linuxAmd64Url;
+        }
+        if ("linuxArm64Url".equals(configInput)) {
+            return linuxArm64Url;
+        }
+
+
+        throw new InvalidKeyException("No url corresponding to " + configInput);
+    }
+
+    private static String downloadFile(String url) throws IOException {
+        String tmpdir = Files.createTempDirectory("sbomgen").toFile().getAbsolutePath();
+        String sbomgenPath = tmpdir + "/inspector_sbomgen.zip";
+
+        try (BufferedInputStream in = new BufferedInputStream(new URL(url).openStream());
+             FileOutputStream fileOutputStream = new FileOutputStream(sbomgenPath)) {
+            byte dataBuffer[] = new byte[1024];
+            int bytesRead;
+            while ((bytesRead = in.read(dataBuffer, 0, 1024)) != -1) {
+                fileOutputStream.write(dataBuffer, 0, bytesRead);
+            }
+        } catch (IOException e) {
+            throw new IOException("There was an issue downloading the SBOMGen utility, please run the plugin by " +
+                    "providing the utility manually.");
+        }
+
+        return sbomgenPath;
+    }
+
+    private static File newFile(File destinationDir, ZipEntry zipEntry) throws IOException {
+        File destFile = new File(destinationDir, zipEntry.getName());
+
+        String destDirPath = destinationDir.getCanonicalPath();
+        String destFilePath = destFile.getCanonicalPath();
+
+        if (!destFilePath.startsWith(destDirPath + File.separator)) {
+            throw new IOException("Entry is outside of the target dir: " + zipEntry.getName());
+        }
+
+        return destFile;
+    }
+
+
+    private static String unzipFile(String zipPath) throws IOException {
+        String destinationPath = zipPath.replace(".zip", "");
+        byte[] buffer = new byte[1024];
+
+        ZipInputStream zis = new ZipInputStream(new FileInputStream(zipPath));
+        ZipEntry zipEntry = zis.getNextEntry();
+        String sbomgenPath = "";
+        while (zipEntry != null) {
+            System.out.println(zipEntry.getName());
+            File newFile = newFile(new File(destinationPath), zipEntry);
+            if (zipEntry.getName().endsWith("inspector-sbomgen")) {
+                sbomgenPath = newFile.getAbsolutePath();
+                newFile.setExecutable(true);
+            }
+            if (zipEntry.isDirectory()) {
+                if (!newFile.isDirectory() && !newFile.mkdirs()) {
+                    throw new IOException("Failed to create directory " + newFile);
+                }
+            } else {
+                File parent = newFile.getParentFile();
+                if (!parent.isDirectory() && !parent.mkdirs()) {
+                    throw new IOException("Failed to create directory " + parent);
+                }
+
+                FileOutputStream fos = new FileOutputStream(newFile);
+                int len;
+                while ((len = zis.read(buffer)) > 0) {
+                    fos.write(buffer, 0, len);
+                }
+                fos.close();
+            }
+            zipEntry = zis.getNextEntry();
+        }
+
+        zis.closeEntry();
+        zis.close();
+
+        return sbomgenPath;
+    }
+
+    private static String copyBinary(String src, String dest) throws IOException {
+        File copied = new File(dest);
+
+        try (
+                InputStream in = new BufferedInputStream(
+                        new FileInputStream(src));
+                OutputStream out = new BufferedOutputStream(
+                        new FileOutputStream(copied))) {
+
+            byte[] buffer = new byte[1024];
+            int lengthRead;
+            while ((lengthRead = in.read(buffer)) > 0) {
+                out.write(buffer, 0, lengthRead);
+                out.flush();
+            }
+        } catch (IOException e) {
+            throw e;
+        }
+
+        copied.setExecutable(true);
+
+        return dest;
+    }
+}

--- a/src/main/java/com/amazon/inspector/jenkins/amazoninspectorbuildstep/sbomgen/SbomgenDownloader.java
+++ b/src/main/java/com/amazon/inspector/jenkins/amazoninspectorbuildstep/sbomgen/SbomgenDownloader.java
@@ -84,12 +84,12 @@ public class SbomgenDownloader {
         ZipEntry zipEntry = zis.getNextEntry();
         String sbomgenPath = "";
         while (zipEntry != null) {
-            System.out.println(zipEntry.getName());
             File newFile = newFile(new File(destinationPath), zipEntry);
             if (zipEntry.getName().endsWith("inspector-sbomgen")) {
                 sbomgenPath = newFile.getAbsolutePath();
                 newFile.setExecutable(true);
             }
+
             if (zipEntry.isDirectory()) {
                 if (!newFile.isDirectory() && !newFile.mkdirs()) {
                     throw new IOException("Failed to create directory " + newFile);
@@ -112,6 +112,7 @@ public class SbomgenDownloader {
 
         zis.closeEntry();
         zis.close();
+
 
         return sbomgenPath;
     }

--- a/src/main/java/com/amazon/inspector/jenkins/amazoninspectorbuildstep/sbomgen/SbomgenRunner.java
+++ b/src/main/java/com/amazon/inspector/jenkins/amazoninspectorbuildstep/sbomgen/SbomgenRunner.java
@@ -45,9 +45,6 @@ public class SbomgenRunner {
             throw new IllegalArgumentException("Invalid sbomgen path: " + sbomgenPath);
         }
 
-        if (!isValidPath(archivePath)) {
-            throw new IllegalArgumentException("Invalid archive path: " + archivePath);
-        }
         AmazonInspectorBuilder.logger.println("Making downloaded SBOMGen executable...");
         new ProcessBuilder(new String[]{"chmod", "+x", sbomgenPath}).start();
 
@@ -63,7 +60,6 @@ public class SbomgenRunner {
             environment.put("INSPECTOR_SBOMGEN_USERNAME", dockerUsername);
             environment.put("INSPECTOR_SBOMGEN_PASSWORD", dockerPassword);
         }
-
 
         builder.redirectErrorStream(true);
         Process p = null;

--- a/src/main/java/com/amazon/inspector/jenkins/amazoninspectorbuildstep/sbomgen/SbomgenRunner.java
+++ b/src/main/java/com/amazon/inspector/jenkins/amazoninspectorbuildstep/sbomgen/SbomgenRunner.java
@@ -80,7 +80,6 @@ public class SbomgenRunner {
         StringBuilder sb = new StringBuilder();
         while (true) {
             line = r.readLine();
-            AmazonInspectorBuilder.logger.println(line);
             sb.append(line + "\n");
             if (line == null) { break; }
         }

--- a/src/main/java/com/amazon/inspector/jenkins/amazoninspectorbuildstep/sbomgen/SbomgenRunner.java
+++ b/src/main/java/com/amazon/inspector/jenkins/amazoninspectorbuildstep/sbomgen/SbomgenRunner.java
@@ -8,6 +8,7 @@ import lombok.Setter;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.util.Arrays;
 import java.util.Map;
 
 import static com.amazon.inspector.jenkins.amazoninspectorbuildstep.sbomgen.SbomgenUtils.processSbomgenOutput;
@@ -47,11 +48,14 @@ public class SbomgenRunner {
         if (!isValidPath(archivePath)) {
             throw new IllegalArgumentException("Invalid archive path: " + archivePath);
         }
+        AmazonInspectorBuilder.logger.println("Making downloaded SBOMGen executable...");
+        new ProcessBuilder(new String[]{"chmod", "+x", sbomgenPath}).start();
 
+        AmazonInspectorBuilder.logger.println("Running command...");
         String[] command = new String[] {
                 sbomgenPath, "container", "--image", archivePath
         };
-
+        AmazonInspectorBuilder.logger.println(Arrays.toString(command));
         ProcessBuilder builder = new ProcessBuilder(command);
         Map<String, String> environment = builder.environment();
 
@@ -76,6 +80,7 @@ public class SbomgenRunner {
         StringBuilder sb = new StringBuilder();
         while (true) {
             line = r.readLine();
+            AmazonInspectorBuilder.logger.println(line);
             sb.append(line + "\n");
             if (line == null) { break; }
         }

--- a/src/main/java/com/amazon/inspector/jenkins/amazoninspectorbuildstep/sbomgen/SbomgenUtils.java
+++ b/src/main/java/com/amazon/inspector/jenkins/amazoninspectorbuildstep/sbomgen/SbomgenUtils.java
@@ -15,7 +15,7 @@ public class SbomgenUtils {
         int endIndex = sbom.lastIndexOf("}");
 
         if (startIndex == -1 || endIndex == -1 || startIndex > endIndex) {
-            throw new MalformedScanOutputException("Sbom output formatted incorrectly: " + sbom);
+            throw new MalformedScanOutputException("Sbom scanning output formatted incorrectly.\nSbom Content:\n" + sbom);
         }
 
         return sbom.substring(startIndex, endIndex + 1);

--- a/src/main/java/com/amazon/inspector/jenkins/amazoninspectorbuildstep/sbomparsing/Severity.java
+++ b/src/main/java/com/amazon/inspector/jenkins/amazoninspectorbuildstep/sbomparsing/Severity.java
@@ -10,7 +10,8 @@ public enum Severity {
     HIGH("high", 3),
     MEDIUM("medium", 2),
     LOW("low", 1),
-    INFO("informational", 0),
+    INFORMATIONAL("informational", 0),
+    INFO("info", 0),
     NONE("none", 0);
 
     private String severityName;
@@ -33,6 +34,7 @@ public enum Severity {
                 return MEDIUM;
             case "low":
                 return LOW;
+            case "info":
             case "informational":
                 return INFO;
             case "none":

--- a/src/main/java/com/amazon/inspector/jenkins/amazoninspectorbuildstep/sbomparsing/SeverityCounts.java
+++ b/src/main/java/com/amazon/inspector/jenkins/amazoninspectorbuildstep/sbomparsing/SeverityCounts.java
@@ -8,6 +8,7 @@ import java.util.Map;
 import static com.amazon.inspector.jenkins.amazoninspectorbuildstep.sbomparsing.Severity.CRITICAL;
 import static com.amazon.inspector.jenkins.amazoninspectorbuildstep.sbomparsing.Severity.HIGH;
 import static com.amazon.inspector.jenkins.amazoninspectorbuildstep.sbomparsing.Severity.INFO;
+import static com.amazon.inspector.jenkins.amazoninspectorbuildstep.sbomparsing.Severity.INFORMATIONAL;
 import static com.amazon.inspector.jenkins.amazoninspectorbuildstep.sbomparsing.Severity.LOW;
 import static com.amazon.inspector.jenkins.amazoninspectorbuildstep.sbomparsing.Severity.MEDIUM;
 import static com.amazon.inspector.jenkins.amazoninspectorbuildstep.sbomparsing.Severity.NONE;
@@ -21,6 +22,7 @@ public class SeverityCounts {
         counts.put(CRITICAL, 0);
         counts.put(HIGH, 0);
         counts.put(MEDIUM, 0);
+        counts.put(INFORMATIONAL, 0);
         counts.put(INFO, 0);
         counts.put(LOW, 0);
         counts.put(NONE, 0);

--- a/src/main/resources/com/amazon/inspector/jenkins/amazoninspectorbuildstep/AmazonInspectorBuilder/config.jelly
+++ b/src/main/resources/com/amazon/inspector/jenkins/amazoninspectorbuildstep/AmazonInspectorBuilder/config.jelly
@@ -30,17 +30,18 @@
         }
     </style>
 
-<!--    <input type="radio" id="html" name="fav_language" value="HTML">-->
-<!--    <label for="html">HTML</label><br>-->
-
-    <f:section title="Automatic SBOMGen Sourcing">
-            <f:radioBlock name="sbomgenSource" title="Linux, AMD64" value="linuxAmd64" checked="${instance.osArch == 'linuxAmd64'}">
-            </f:radioBlock>
-            <f:radioBlock name="sbomgenSource" title="Linux, ARM64" value="linuxArm64" checked="${instance.osArch == 'linuxArm64'}">
-            </f:radioBlock>
-            <f:radioBlock name="sbomgenSource" title="Test" value="test" checked="${instance.osArch == 'linuxArm64'}">
-            </f:radioBlock>
-    </f:section>
+<!--    <f:radioBlock title="Automatic SBOMGen Sourcing" name="sbomgenSelection" checked="true" value="auto">-->
+        <f:radioBlock name="sbomgenSource" title="Linux, AMD64" value="linuxAmd64" checked="false">
+        </f:radioBlock>
+        <f:radioBlock name="sbomgenSource" title="Linux, ARM64" value="linuxArm64" checked="false">
+        </f:radioBlock>
+<!--    </f:radioBlock>-->
+<!--    <f:radioBlock title="Manual SBOMGen Sourcing" name="sbomgenSelection" checked="false" value="manual">-->
+        <strong class="required-field">Path to inspector-sbomgen</strong>
+        <f:entry field="sbomgenPath">
+            <f:textbox placeholder="/Users/user/Downloads/inspector-sbomgen"/>
+        </f:entry>
+<!--    </f:radioBlock>-->
 
     <strong class="required-field">Image Id</strong>
     <f:entry field="archivePath">

--- a/src/main/resources/com/amazon/inspector/jenkins/amazoninspectorbuildstep/AmazonInspectorBuilder/config.jelly
+++ b/src/main/resources/com/amazon/inspector/jenkins/amazoninspectorbuildstep/AmazonInspectorBuilder/config.jelly
@@ -30,10 +30,17 @@
         }
     </style>
 
-    <strong class="required-field">Path to inspector-sbomgen</strong>
-    <f:entry field="sbomgenPath">
-        <f:textbox placeholder="/Users/user/Downloads/inspector-sbomgen" value="${it.sbomgenPath}"/>
-    </f:entry>
+<!--    <input type="radio" id="html" name="fav_language" value="HTML">-->
+<!--    <label for="html">HTML</label><br>-->
+
+    <f:section title="Automatic SBOMGen Sourcing">
+            <f:radioBlock name="sbomgenSource" title="Linux, AMD64" value="linuxAmd64" checked="${instance.osArch == 'linuxAmd64'}">
+            </f:radioBlock>
+            <f:radioBlock name="sbomgenSource" title="Linux, ARM64" value="linuxArm64" checked="${instance.osArch == 'linuxArm64'}">
+            </f:radioBlock>
+            <f:radioBlock name="sbomgenSource" title="Test" value="test" checked="${instance.osArch == 'linuxArm64'}">
+            </f:radioBlock>
+    </f:section>
 
     <strong class="required-field">Image Id</strong>
     <f:entry field="archivePath">

--- a/src/main/resources/com/amazon/inspector/jenkins/amazoninspectorbuildstep/AmazonInspectorBuilder/config.jelly
+++ b/src/main/resources/com/amazon/inspector/jenkins/amazoninspectorbuildstep/AmazonInspectorBuilder/config.jelly
@@ -30,18 +30,20 @@
         }
     </style>
 
-<!--    <f:radioBlock title="Automatic SBOMGen Sourcing" name="sbomgenSelection" checked="true" value="auto">-->
+    <f:radioBlock title="Automatic SBOMGen Sourcing" name="sbomgenSelection"
+                  checked="false" value="automatic">
         <f:radioBlock name="sbomgenSource" title="Linux, AMD64" value="linuxAmd64" checked="false">
         </f:radioBlock>
         <f:radioBlock name="sbomgenSource" title="Linux, ARM64" value="linuxArm64" checked="false">
         </f:radioBlock>
-<!--    </f:radioBlock>-->
-<!--    <f:radioBlock title="Manual SBOMGen Sourcing" name="sbomgenSelection" checked="false" value="manual">-->
+    </f:radioBlock>
+    <f:radioBlock title="Manual SBOMGen Sourcing" name="sbomgenSelection" checked="${instance.isSource('manual')}"
+                  value="manual">
         <strong class="required-field">Path to inspector-sbomgen</strong>
         <f:entry field="sbomgenPath">
             <f:textbox placeholder="/Users/user/Downloads/inspector-sbomgen"/>
         </f:entry>
-<!--    </f:radioBlock>-->
+    </f:radioBlock>
 
     <strong class="required-field">Image Id</strong>
     <f:entry field="archivePath">

--- a/src/main/resources/com/amazon/inspector/jenkins/amazoninspectorbuildstep/AmazonInspectorBuilder/config.jelly
+++ b/src/main/resources/com/amazon/inspector/jenkins/amazoninspectorbuildstep/AmazonInspectorBuilder/config.jelly
@@ -30,14 +30,16 @@
         }
     </style>
 
-    <f:radioBlock title="Automatic SBOMGen Sourcing" name="sbomgenSelection"
-                  checked="false" value="automatic">
+    <f:entry field="sbomgenSelectionWrapper" title="Inspector-sbomgen Installation Method"></f:entry>
+
+    <f:radioBlock title="Automatic" name="sbomgenSelection" checked="${instance.isSource('automatic')}" value="automatic">
         <f:radioBlock name="sbomgenSource" title="Linux, AMD64" value="linuxAmd64" checked="false">
         </f:radioBlock>
         <f:radioBlock name="sbomgenSource" title="Linux, ARM64" value="linuxArm64" checked="false">
         </f:radioBlock>
     </f:radioBlock>
-    <f:radioBlock title="Manual SBOMGen Sourcing" name="sbomgenSelection" checked="${instance.isSource('manual')}"
+
+    <f:radioBlock title="Manual" name="sbomgenSelection" checked="${instance.isSource('manual')}"
                   value="manual">
         <strong class="required-field">Path to inspector-sbomgen</strong>
         <f:entry field="sbomgenPath">

--- a/src/main/resources/com/amazon/inspector/jenkins/amazoninspectorbuildstep/AmazonInspectorBuilder/help-sbomgenSelectionWrapper.html
+++ b/src/main/resources/com/amazon/inspector/jenkins/amazoninspectorbuildstep/AmazonInspectorBuilder/help-sbomgenSelectionWrapper.html
@@ -1,0 +1,15 @@
+<div>
+    <p>
+        Automatic: Allows the plugin to download the most recently released version of inspector-sbomgen.
+        Requires selection of the operating system and CPU architecture in use.
+    </p>
+    <p>
+        Manual: Requires a path to a pre-downloaded version of inspector-sbomgen to be supplied.
+    </p>
+    <p>
+        For more info:
+        <a href="https://docs.aws.amazon.com/inspector/latest/user/sbom-generator.html">
+            https://docs.aws.amazon.com/inspector/latest/user/sbom-generator.html
+        </a>
+    </p>
+</div>


### PR DESCRIPTION
- The plugin can now download inspector-sbomgen automatically for linux versions.

- Properly handle Null credential IDs for declarative pipelines.
- The full SBOM will be logged in the event that inspector-sbomgen output cannot be parsed.