### PR TITLE
Adding support for explicit credentials.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -126,6 +126,30 @@
             <artifactId>aws-credentials</artifactId>
             <version>218.v1b_e9466ec5da_</version>
         </dependency>
+
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>credentials</artifactId>
+            <version>1271.v54b_1c2c6388a_</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+            <version>4.5.14</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpcore</artifactId>
+            <version>4.4.16</version>
+        </dependency>
+
+        <dependency>
+            <groupId>io.jenkins.plugins</groupId>
+            <artifactId>javax-activation-api</artifactId>
+            <version>1.2.0-6</version>
+        </dependency>
     </dependencies>
 
     <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -120,6 +120,12 @@
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>aws-json-protocol</artifactId>
         </dependency>
+
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>aws-credentials</artifactId>
+            <version>218.v1b_e9466ec5da_</version>
+        </dependency>
     </dependencies>
 
     <repositories>

--- a/src/main/java/com/amazon/inspector/jenkins/amazoninspectorbuildstep/AmazonInspectorBuilder.java
+++ b/src/main/java/com/amazon/inspector/jenkins/amazoninspectorbuildstep/AmazonInspectorBuilder.java
@@ -168,13 +168,13 @@ public class AmazonInspectorBuilder extends Builder implements SimpleBuildStep {
             String imageSha = getImageSha(sbom);
 
             listener.getLogger().print("Sending SBOM to Inspector for validation ");
+            AmazonWebServicesCredentials awsCredential = null;
             if (awsCredentialId != null) {
                 listener.getLogger().print("with credential:" + awsCredentialId);
+                awsCredential = CredentialsProvider.findCredentialById(awsCredentialId,
+                        AmazonWebServicesCredentials.class, build);
             }
             listener.getLogger().print("\n");
-
-            AmazonWebServicesCredentials awsCredential = CredentialsProvider.findCredentialById(awsCredentialId,
-                    AmazonWebServicesCredentials.class, build);
 
             String responseData = new SdkRequests(awsRegion, awsCredential, iamRole).requestSbom(sbom);
 

--- a/src/main/java/com/amazon/inspector/jenkins/amazoninspectorbuildstep/AmazonInspectorBuilder.java
+++ b/src/main/java/com/amazon/inspector/jenkins/amazoninspectorbuildstep/AmazonInspectorBuilder.java
@@ -1,6 +1,7 @@
 package com.amazon.inspector.jenkins.amazoninspectorbuildstep;
 
 import com.amazon.inspector.jenkins.amazoninspectorbuildstep.sbomgen.SbomgenDownloader;
+import com.cloudbees.jenkins.plugins.awscredentials.AmazonWebServicesCredentials;
 import com.cloudbees.plugins.credentials.CredentialsProvider;
 import com.cloudbees.plugins.credentials.common.StandardUsernamePasswordCredentials;
 import com.google.gson.Gson;
@@ -82,15 +83,17 @@ public class AmazonInspectorBuilder extends Builder implements SimpleBuildStep {
     private final int countHigh;
     private final int countMedium;
     private final int countLow;
+    private final String awsCredentialId;
     private Job<?, ?> job;
 
     @DataBoundConstructor
     public AmazonInspectorBuilder(String archivePath, String sbomgenPath, boolean osArch, String iamRole, String awsRegion,
-                                  String credentialId, String sbomgenMethod, String sbomgenSource,
+                                  String credentialId, String awsCredentialId, String sbomgenMethod, String sbomgenSource,
                                   boolean isThresholdEnabled, int countCritical, int countHigh, int countMedium,
                                   int countLow) {
         this.archivePath = archivePath;
         this.credentialId = credentialId;
+        this.awsCredentialId = awsCredentialId;
         this.sbomgenSource = sbomgenSource;
         this.sbomgenPath = sbomgenPath;
         this.sbomgenMethod = sbomgenMethod;
@@ -150,7 +153,7 @@ public class AmazonInspectorBuilder extends Builder implements SimpleBuildStep {
 
             String sbom;
             if (credential != null) {
-                logger.println("Running inspector-sbomgen with credential: " + credential.getId());
+                logger.println("Running inspector-sbomgen with docker credential: " + credential.getId());
                 sbom = new SbomgenRunner(activeSbomgenPath, archivePath, credential.getUsername(),
                         credential.getPassword().getPlainText()).run();
             } else {
@@ -164,8 +167,16 @@ public class AmazonInspectorBuilder extends Builder implements SimpleBuildStep {
             Gson gson = new GsonBuilder().setPrettyPrinting().disableHtmlEscaping().create();
             String imageSha = getImageSha(sbom);
 
-            listener.getLogger().println("Sending SBOM to Inspector for validation");
-            String responseData = new SdkRequests(awsRegion, iamRole).requestSbom(sbom);
+            listener.getLogger().print("Sending SBOM to Inspector for validation ");
+            if (awsCredentialId != null) {
+                listener.getLogger().print("with credential:" + awsCredentialId);
+            }
+            listener.getLogger().print("\n");
+
+            AmazonWebServicesCredentials awsCredential = CredentialsProvider.findCredentialById(awsCredentialId,
+                    AmazonWebServicesCredentials.class, build);
+
+            String responseData = new SdkRequests(awsRegion, awsCredential, iamRole).requestSbom(sbom);
 
             SbomData sbomData = SbomData.builder().sbom(gson.fromJson(responseData, Sbom.class)).build();
 
@@ -341,6 +352,34 @@ public class AmazonInspectorBuilder extends Builder implements SimpleBuildStep {
         public ListBoxModel doFillCredentialIdItems() {
             if (Jenkins.get().hasPermission(READ)) {
                 return getCredentialIdModels();
+            }
+            return new ListBoxModel();
+        }
+
+        private ListBoxModel getAwsCredentialIdModels() {
+            ListBoxModel items = new ListBoxModel();
+            List<AmazonWebServicesCredentials> credentials = CredentialsProvider.lookupCredentials(
+                    AmazonWebServicesCredentials.class,
+                    Jenkins.getInstance(),
+                    ACL.SYSTEM,
+                    Collections.emptyList()
+            );
+
+            items.add("Select AWS Credentials", null);
+            for (AmazonWebServicesCredentials credential : credentials) {
+                if (credential.getCredentials() != null && !credential.getCredentials().getAWSAccessKeyId().isEmpty()) {
+                    items.add(String.format("[%s] %s", credential.getId(), credential.getDisplayName()),
+                            credential.getId());
+                }
+            }
+
+            return items;
+        }
+
+        @POST
+        public ListBoxModel doFillAwsCredentialIdItems() {
+            if (Jenkins.get().hasPermission(READ)) {
+                return getAwsCredentialIdModels();
             }
             return new ListBoxModel();
         }

--- a/src/main/java/com/amazon/inspector/jenkins/amazoninspectorbuildstep/AmazonInspectorBuilder.java
+++ b/src/main/java/com/amazon/inspector/jenkins/amazoninspectorbuildstep/AmazonInspectorBuilder.java
@@ -367,7 +367,7 @@ public class AmazonInspectorBuilder extends Builder implements SimpleBuildStep {
 
             items.add("Select AWS Credentials", null);
             for (AmazonWebServicesCredentials credential : credentials) {
-                if (credential.getCredentials() != null && !credential.getCredentials().getAWSAccessKeyId().isEmpty()) {
+                if (credential != null && credential.getCredentials() != null) {
                     items.add(String.format("[%s] %s", credential.getId(), credential.getDisplayName()),
                             credential.getId());
                 }

--- a/src/main/java/com/amazon/inspector/jenkins/amazoninspectorbuildstep/AmazonInspectorBuilder.java
+++ b/src/main/java/com/amazon/inspector/jenkins/amazoninspectorbuildstep/AmazonInspectorBuilder.java
@@ -356,6 +356,7 @@ public class AmazonInspectorBuilder extends Builder implements SimpleBuildStep {
             return new ListBoxModel();
         }
 
+        @SuppressFBWarnings()
         private ListBoxModel getAwsCredentialIdModels() {
             ListBoxModel items = new ListBoxModel();
             List<AmazonWebServicesCredentials> credentials = CredentialsProvider.lookupCredentials(

--- a/src/main/resources/com/amazon/inspector/jenkins/amazoninspectorbuildstep/AmazonInspectorBuilder/config.jelly
+++ b/src/main/resources/com/amazon/inspector/jenkins/amazoninspectorbuildstep/AmazonInspectorBuilder/config.jelly
@@ -66,6 +66,10 @@
         <f:select clazz="padding"></f:select>
     </f:entry>
 
+    <f:entry field="awsCredentialId" title="AWS Credentials">
+        <f:select clazz="padding"></f:select>
+    </f:entry>
+
 
     <f:entry field="isThresholdEnabled">
         <f:checkbox id="isThresholdEnabled" class="bold" checked="false"

--- a/src/main/resources/com/amazon/inspector/jenkins/amazoninspectorbuildstep/AmazonInspectorBuilder/help-awsCredentialId.html
+++ b/src/main/resources/com/amazon/inspector/jenkins/amazoninspectorbuildstep/AmazonInspectorBuilder/help-awsCredentialId.html
@@ -1,0 +1,15 @@
+<div>
+    <p>
+        Optional. Allows you to specify AWS credentials explicitly instead of having them be pulled from your system.
+        If this option is omitted, AWS credentials will be obtained via the default provider chain.
+    </p>
+    <p>
+        Credentials must be added to the credential store as the "AWS Credentials" type.
+    </p>
+    <p>
+        For more info:
+        <a href="https://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/credentials.html#credentials-default">
+            https://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/credentials.html#credentials-default
+        </a>
+    </p>
+</div>


### PR DESCRIPTION
Credentials can now be specified in the plugin itself. This is done via jenkins credential store as the "AWS Credentials" credential type.

<img width="1215" alt="Screenshot 2024-01-18 at 11 27 25 AM" src="https://github.com/jenkinsci/amazon-inspector-image-scanner-plugin/assets/144280698/c50ac781-adb3-4166-9766-2287a093d8bb">
